### PR TITLE
Ignore ansible errors when executing shell command in test_interface_binding

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -225,8 +225,9 @@ def testing_config(request, duthosts, rand_one_dut_hostname, tbinfo):
             restart_dhcp_service(duthost)
 
 def check_interface_status(duthost):
-    if ":67" in duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcrelay")["stdout"].encode("utf-8"):
+    if ":67" in duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcrelay", module_ignore_errors=True)["stdout"].encode("utf-8"):
         return True
+
     return False
 
 def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
@@ -236,7 +237,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data)
         config_reload(duthost)
         wait_critical_processes(duthost)
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
-    output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcrelay")["stdout"].encode("utf-8")
+    output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcrelay", module_ignore_errors=True)["stdout"].encode("utf-8")
     logger.info(output)
     for dhcp_relay in dut_dhcp_relay_data:
         assert "{}:67".format(dhcp_relay['downlink_vlan_iface']['name']) in output, "{} is not found in {}".format("{}:67".format(dhcp_relay['downlink_vlan_iface']['name']), output)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This change is to enhance the stability of test_dhcp_relay.py::test_interface_binding by ignoring ansible errors when executing shell command.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This change is to enhance the stability of test_interface_binding.
#### How did you do it?
There is already logic to verify if the dhcp relay agents are running correctly in test_interface_binding by executing command "docker exec -it dhcp_relay ss -nlp | grep dhcrelay" on the DUT. And if this command get nothing from the DUT, the test will try to reload config to make sure dhcp relay agents are good before running other tests.
However, if "docker exec -it dhcp_relay ss -nlp | grep dhcrelay" does get nothing(stdout is empty ), the ansible method will fail immediately and won't return to the caller function, so the verify and config reload logic will be useless, which means the effort to make this test stable is in vain.
To resolve this, need to set module_ignore_errors as True to ignore ansible errors.
#### How did you verify/test it?
Verified on to setups.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
